### PR TITLE
Fixup: don't double-urlencode the caller's query text

### DIFF
--- a/src/pymojeek/__init__.py
+++ b/src/pymojeek/__init__.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 import json
 from typing import Any, Dict, List, Optional
 
-from urllib.parse import quote as urlquote, urlencode
+from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 
@@ -133,7 +133,7 @@ class Search:
         params = {
             "api_key": self.api_key,
             "fmt": "json",
-            "q": urlquote(query),
+            "q": query,
         }
         if start is not None:
             params["s"] = str(int(start))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -17,6 +17,9 @@ class SearchTest(TestCase):
         mock_urlopen.return_value = SearchTest.MockResponse()
 
         client = Search(api_key="000000000000000000000000")
-        client.search("testing")
+        client.search("testing testing one two three")
 
         self.assertTrue(mock_urlopen.called)
+        outbound_request = mock_urlopen.call_args_list[0].args[0]
+        requested_url = outbound_request.get_full_url()
+        self.assertIn("&q=testing+testing+one+two+three", requested_url)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Allows input queries that contain spaces and other non-URL-charset characters to be encoded correctly.

### Briefly summarize the changes
1. Remove the `urllib.parse.quote` call on the `query` argument provided by the caller, since this will later be URL-encoded by `urllib.parse.urlencode`.

### How have the changes been tested?
1. Unit test coverage is provided. 

**List any issues that this change relates to**
Resolves #2.